### PR TITLE
[VCDA-2561 & VCDA-2565] remove docker registry on control plane and edit tkgm description

### DIFF
--- a/scripts/ubuntu-20.04_tkgm-1.20_antrea-0.11_rev1/cust.sh
+++ b/scripts/ubuntu-20.04_tkgm-1.20_antrea-0.11_rev1/cust.sh
@@ -51,9 +51,6 @@ apt install -y ./kubeadm_1.20.4+vmware.1-1_amd64.deb ./kubectl_1.20.4+vmware.1-1
 systemctl restart kubelet
 while [ `systemctl is-active kubelet` != 'active' ]; do echo 'waiting for kubelet'; sleep 5; done
 
-# set up local container image repository
-docker run -d -p 5000:5000 --restart=always --name registry registry:2
-
 # Install kubernetes components, coredns, and antrea binary
 wget https://github.com/ltimothy7/container-service-extension-templates/raw/tkgm/tkgm_build_artifacts/1_3_0/kube-proxy-v1.20.4_vmware.1.tar.gz
 wget https://github.com/ltimothy7/container-service-extension-templates/raw/tkgm/tkgm_build_artifacts/1_3_0/kube-apiserver-v1.20.4_vmware.1.tar.gz
@@ -74,13 +71,13 @@ docker load -i coredns-v1.7.0_vmware.8.tar.gz
 docker load -i antrea-debian-v0.11.3_vmware.2.tar.gz
 docker load -i pause-3.2.tar.gz
 
-docker tag projects.registry.vmware.com/tkg/kube-proxy:v1.20.4_vmware.1 localhost:5000/kube-proxy:v1.20.4
-docker tag projects.registry.vmware.com/tkg/kube-apiserver:v1.20.4_vmware.1 localhost:5000/kube-apiserver:v1.20.4
-docker tag projects.registry.vmware.com/tkg/kube-controller-manager:v1.20.4_vmware.1 localhost:5000/kube-controller-manager:v1.20.4
-docker tag projects.registry.vmware.com/tkg/kube-scheduler:v1.20.4_vmware.1 localhost:5000/kube-scheduler:v1.20.4
-docker tag projects.registry.vmware.com/tkg/etcd:v3.4.13_vmware.7 localhost:5000/etcd:3.4.13-0
-docker tag projects.registry.vmware.com/tkg/coredns:v1.7.0_vmware.8 localhost:5000/coredns:1.7.0
-docker tag projects.registry.vmware.com/tkg/pause:3.2 localhost:5000/pause:3.2
+docker tag projects.registry.vmware.com/tkg/kube-proxy:v1.20.4_vmware.1 k8s.gcr.io/kube-proxy:v1.20.4-vmware.1
+docker tag projects.registry.vmware.com/tkg/kube-apiserver:v1.20.4_vmware.1 k8s.gcr.io/kube-apiserver:v1.20.4-vmware.1
+docker tag projects.registry.vmware.com/tkg/kube-controller-manager:v1.20.4_vmware.1 k8s.gcr.io/kube-controller-manager:v1.20.4-vmware.1
+docker tag projects.registry.vmware.com/tkg/kube-scheduler:v1.20.4_vmware.1 k8s.gcr.io/kube-scheduler:v1.20.4-vmware.1
+docker tag projects.registry.vmware.com/tkg/etcd:v3.4.13_vmware.7 k8s.gcr.io/etcd:3.4.13-0-vmware.7
+docker tag projects.registry.vmware.com/tkg/coredns:v1.7.0_vmware.8 k8s.gcr.io/coredns:1.7.0-vmware.8
+docker tag projects.registry.vmware.com/tkg/pause:3.2 k8s.gcr.io/pause:3.2
 
 echo 'installing required software for NFS'
 apt-get -q install -y nfs-common nfs-kernel-server

--- a/scripts/ubuntu-20.04_tkgm-1.20_antrea-0.11_rev1/cust.sh
+++ b/scripts/ubuntu-20.04_tkgm-1.20_antrea-0.11_rev1/cust.sh
@@ -9,16 +9,12 @@ echo 'net.ipv6.conf.lo.disable_ipv6 = 1' >> /etc/sysctl.conf
 sudo sysctl -p
 
 # setup resolvconf for ubuntu 20
-echo 'nameserver 8.8.4.4' >> /etc/resolv.conf
 echo 'nameserver 8.8.8.8' >> /etc/resolv.conf
 apt update
 apt install resolvconf
 systemctl restart resolvconf.service
-echo 'nameserver 10.16.188.210' >> /etc/resolvconf/resolv.conf.d/head
-echo 'nameserver 10.118.254.1' >> /etc/resolvconf/resolv.conf.d/head
+while [ `systemctl is-active resolvconf` != 'active' ]; do echo 'waiting for resolvconf'; sleep 5; done
 echo 'nameserver 8.8.8.8' >> /etc/resolvconf/resolv.conf.d/head
-echo 'nameserver 8.8.4.4' >> /etc/resolvconf/resolv.conf.d/head
-resolvconf --enable-updates
 resolvconf -u
 
 #systemctl restart networking.service
@@ -47,9 +43,9 @@ apt-get -q install -y kubernetes-cni=0.8.7-00 # kubernetes-cni is needed for kub
 apt-get -q install -y docker-ce=5:19.03.15~3-0~ubuntu-focal docker-ce-cli=5:19.03.15~3-0~ubuntu-focal containerd.io
 systemctl restart docker
 while [ `systemctl is-active docker` != 'active' ]; do echo 'waiting for docker'; sleep 5; done
-wget https://github.com/ltimothy7/container-service-extension-templates/blob/tkgm/tkgm_build_artifacts/1_3_0/kubeadm_1.20.4%2Bvmware.1-1_amd64.deb
-wget https://github.com/ltimothy7/container-service-extension-templates/blob/tkgm/tkgm_build_artifacts/1_3_0/kubectl_1.20.4%2Bvmware.1-1_amd64.deb
-wget https://github.com/ltimothy7/container-service-extension-templates/blob/tkgm/tkgm_build_artifacts/1_3_0/kubelet_1.20.4%2Bvmware.1-1_amd64.deb
+wget https://github.com/ltimothy7/container-service-extension-templates/raw/tkgm/tkgm_build_artifacts/1_3_0/kubeadm_1.20.4%2Bvmware.1-1_amd64.deb
+wget https://github.com/ltimothy7/container-service-extension-templates/raw/tkgm/tkgm_build_artifacts/1_3_0/kubectl_1.20.4%2Bvmware.1-1_amd64.deb
+wget https://github.com/ltimothy7/container-service-extension-templates/raw/tkgm/tkgm_build_artifacts/1_3_0/kubelet_1.20.4%2Bvmware.1-1_amd64.deb
 # Installing all three at once since they depend on one another
 apt install -y ./kubeadm_1.20.4+vmware.1-1_amd64.deb ./kubectl_1.20.4+vmware.1-1_amd64.deb ./kubelet_1.20.4+vmware.1-1_amd64.deb
 systemctl restart kubelet
@@ -59,15 +55,15 @@ while [ `systemctl is-active kubelet` != 'active' ]; do echo 'waiting for kubele
 docker run -d -p 5000:5000 --restart=always --name registry registry:2
 
 # Install kubernetes components, coredns, and antrea binary
-wget https://github.com/ltimothy7/container-service-extension-templates/blob/tkgm/tkgm_build_artifacts/1_3_0/kube-proxy-v1.20.4_vmware.1.tar.gz
-wget https://github.com/ltimothy7/container-service-extension-templates/blob/tkgm/tkgm_build_artifacts/1_3_0/kube-apiserver-v1.20.4_vmware.1.tar.gz
-wget https://github.com/ltimothy7/container-service-extension-templates/blob/tkgm/tkgm_build_artifacts/1_3_0/kube-controller-manager-v1.20.4_vmware.1.tar.gz
-wget https://github.com/ltimothy7/container-service-extension-templates/blob/tkgm/tkgm_build_artifacts/1_3_0/kube-scheduler-v1.20.4_vmware.1.tar.gz
-wget https://github.com/ltimothy7/container-service-extension-templates/blob/tkgm/tkgm_build_artifacts/1_3_0/etcd-v3.4.13_vmware.7.tar.gz
-wget https://github.com/ltimothy7/container-service-extension-templates/blob/tkgm/tkgm_build_artifacts/1_3_0/coredns-v1.7.0_vmware.8.tar.gz
-wget https://github.com/ltimothy7/container-service-extension-templates/blob/tkgm/tkgm_build_artifacts/1_3_0/pause-3.2.tar.gz
-wget https://github.com/ltimothy7/container-service-extension-templates/blob/tkgm/tkgm_build_artifacts/1_3_0/antrea-debian-v0.11.3_vmware.2.tar.gz.partaa
-wget https://github.com/ltimothy7/container-service-extension-templates/blob/tkgm/tkgm_build_artifacts/1_3_0/antrea-debian-v0.11.3_vmware.2.tar.gz.partab
+wget https://github.com/ltimothy7/container-service-extension-templates/raw/tkgm/tkgm_build_artifacts/1_3_0/kube-proxy-v1.20.4_vmware.1.tar.gz
+wget https://github.com/ltimothy7/container-service-extension-templates/raw/tkgm/tkgm_build_artifacts/1_3_0/kube-apiserver-v1.20.4_vmware.1.tar.gz
+wget https://github.com/ltimothy7/container-service-extension-templates/raw/tkgm/tkgm_build_artifacts/1_3_0/kube-controller-manager-v1.20.4_vmware.1.tar.gz
+wget https://github.com/ltimothy7/container-service-extension-templates/raw/tkgm/tkgm_build_artifacts/1_3_0/kube-scheduler-v1.20.4_vmware.1.tar.gz
+wget https://github.com/ltimothy7/container-service-extension-templates/raw/tkgm/tkgm_build_artifacts/1_3_0/etcd-v3.4.13_vmware.7.tar.gz
+wget https://github.com/ltimothy7/container-service-extension-templates/raw/tkgm/tkgm_build_artifacts/1_3_0/coredns-v1.7.0_vmware.8.tar.gz
+wget https://github.com/ltimothy7/container-service-extension-templates/raw/tkgm/tkgm_build_artifacts/1_3_0/pause-3.2.tar.gz
+wget https://github.com/ltimothy7/container-service-extension-templates/raw/tkgm/tkgm_build_artifacts/1_3_0/antrea-debian-v0.11.3_vmware.2.tar.gz.partaa
+wget https://github.com/ltimothy7/container-service-extension-templates/raw/tkgm/tkgm_build_artifacts/1_3_0/antrea-debian-v0.11.3_vmware.2.tar.gz.partab
 cat antrea-debian-v0.11.3_vmware.2.tar.gz.partaa antrea-debian-v0.11.3_vmware.2.tar.gz.partab > antrea-debian-v0.11.3_vmware.2.tar.gz
 docker load -i kube-proxy-v1.20.4_vmware.1.tar.gz
 docker load -i kube-apiserver-v1.20.4_vmware.1.tar.gz

--- a/scripts/ubuntu-20.04_tkgm-1.20_antrea-0.11_rev1/cust.sh
+++ b/scripts/ubuntu-20.04_tkgm-1.20_antrea-0.11_rev1/cust.sh
@@ -47,9 +47,9 @@ apt-get -q install -y kubernetes-cni=0.8.7-00 # kubernetes-cni is needed for kub
 apt-get -q install -y docker-ce=5:19.03.15~3-0~ubuntu-focal docker-ce-cli=5:19.03.15~3-0~ubuntu-focal containerd.io
 systemctl restart docker
 while [ `systemctl is-active docker` != 'active' ]; do echo 'waiting for docker'; sleep 5; done
-wget http://build-squid.eng.vmware.com/build/mts/release/bora-17654488/publish/lin64/kubernetes/debs/kubeadm_1.20.4+vmware.1-1_amd64.deb
-wget http://build-squid.eng.vmware.com/build/mts/release/bora-17654488/publish/lin64/kubernetes/debs/kubectl_1.20.4+vmware.1-1_amd64.deb
-wget http://build-squid.eng.vmware.com/build/mts/release/bora-17654488/publish/lin64/kubernetes/debs/kubelet_1.20.4+vmware.1-1_amd64.deb
+wget https://github.com/ltimothy7/container-service-extension-templates/blob/tkgm/tkgm_build_artifacts/1_3_0/kubeadm_1.20.4%2Bvmware.1-1_amd64.deb
+wget https://github.com/ltimothy7/container-service-extension-templates/blob/tkgm/tkgm_build_artifacts/1_3_0/kubectl_1.20.4%2Bvmware.1-1_amd64.deb
+wget https://github.com/ltimothy7/container-service-extension-templates/blob/tkgm/tkgm_build_artifacts/1_3_0/kubelet_1.20.4%2Bvmware.1-1_amd64.deb
 # Installing all three at once since they depend on one another
 apt install -y ./kubeadm_1.20.4+vmware.1-1_amd64.deb ./kubectl_1.20.4+vmware.1-1_amd64.deb ./kubelet_1.20.4+vmware.1-1_amd64.deb
 systemctl restart kubelet
@@ -59,14 +59,16 @@ while [ `systemctl is-active kubelet` != 'active' ]; do echo 'waiting for kubele
 docker run -d -p 5000:5000 --restart=always --name registry registry:2
 
 # Install kubernetes components, coredns, and antrea binary
-wget http://build-squid.eng.vmware.com/build/mts/release/bora-17654488/publish/lin64/kubernetes/images/kube-proxy-v1.20.4_vmware.1.tar.gz
-wget http://build-squid.eng.vmware.com/build/mts/release/bora-17654488/publish/lin64/kubernetes/images/kube-apiserver-v1.20.4_vmware.1.tar.gz
-wget http://build-squid.eng.vmware.com/build/mts/release/bora-17654488/publish/lin64/kubernetes/images/kube-controller-manager-v1.20.4_vmware.1.tar.gz
-wget http://build-squid.eng.vmware.com/build/mts/release/bora-17654488/publish/lin64/kubernetes/images/kube-scheduler-v1.20.4_vmware.1.tar.gz
-wget http://build-squid.eng.vmware.com/build/mts/release/bora-17654397/publish/lin64/etcd/images/etcd-v3.4.13_vmware.7.tar.gz
-wget http://build-squid.eng.vmware.com/build/mts/release/bora-17654431/publish/lin64/coredns/images/coredns-v1.7.0_vmware.8.tar.gz
-wget http://build-squid.eng.vmware.com/build/mts/release/bora-17827694/publish/lin64/antrea/images/antrea-debian-v0.11.3_vmware.2.tar.gz
-wget http://build-squid.eng.vmware.com/build/mts/release/bora-17654488/publish/lin64/kubernetes/images/pause-3.2.tar.gz
+wget https://github.com/ltimothy7/container-service-extension-templates/blob/tkgm/tkgm_build_artifacts/1_3_0/kube-proxy-v1.20.4_vmware.1.tar.gz
+wget https://github.com/ltimothy7/container-service-extension-templates/blob/tkgm/tkgm_build_artifacts/1_3_0/kube-apiserver-v1.20.4_vmware.1.tar.gz
+wget https://github.com/ltimothy7/container-service-extension-templates/blob/tkgm/tkgm_build_artifacts/1_3_0/kube-controller-manager-v1.20.4_vmware.1.tar.gz
+wget https://github.com/ltimothy7/container-service-extension-templates/blob/tkgm/tkgm_build_artifacts/1_3_0/kube-scheduler-v1.20.4_vmware.1.tar.gz
+wget https://github.com/ltimothy7/container-service-extension-templates/blob/tkgm/tkgm_build_artifacts/1_3_0/etcd-v3.4.13_vmware.7.tar.gz
+wget https://github.com/ltimothy7/container-service-extension-templates/blob/tkgm/tkgm_build_artifacts/1_3_0/coredns-v1.7.0_vmware.8.tar.gz
+wget https://github.com/ltimothy7/container-service-extension-templates/blob/tkgm/tkgm_build_artifacts/1_3_0/pause-3.2.tar.gz
+wget https://github.com/ltimothy7/container-service-extension-templates/blob/tkgm/tkgm_build_artifacts/1_3_0/antrea-debian-v0.11.3_vmware.2.tar.gz.partaa
+wget https://github.com/ltimothy7/container-service-extension-templates/blob/tkgm/tkgm_build_artifacts/1_3_0/antrea-debian-v0.11.3_vmware.2.tar.gz.partab
+cat antrea-debian-v0.11.3_vmware.2.tar.gz.partaa antrea-debian-v0.11.3_vmware.2.tar.gz.partab > antrea-debian-v0.11.3_vmware.2.tar.gz
 docker load -i kube-proxy-v1.20.4_vmware.1.tar.gz
 docker load -i kube-apiserver-v1.20.4_vmware.1.tar.gz
 docker load -i kube-controller-manager-v1.20.4_vmware.1.tar.gz

--- a/scripts/ubuntu-20.04_tkgm-1.20_antrea-0.11_rev1/mstr.sh
+++ b/scripts/ubuntu-20.04_tkgm-1.20_antrea-0.11_rev1/mstr.sh
@@ -4,8 +4,7 @@ while [ `systemctl is-active docker` != 'active' ]; do echo 'waiting for docker'
 kubeadm init \
   --pod-network-cidr={pod_network_cidr} \
   --service-cidr={service_cidr} \
-  --kubernetes-version=1.20.4 \
-  --image-repository "localhost:5000" \
+  --kubernetes-version=1.20.4-vmware.1 \
   > /root/kubeadm-init.out
 mkdir -p /root/.kube
 cp -f /etc/kubernetes/admin.conf /root/.kube/config

--- a/template.yaml
+++ b/template.yaml
@@ -2,7 +2,7 @@ templates:
   - compute_policy: ""
     cpu: 2
     deprecated: false
-    description: "Ubuntu 20.04, Docker-ce 19.03.15, Kubernetes 1.20.4 (VMware TKG-m), Antrea 0.11.3"
+    description: "Ubuntu 20.04, Docker-ce 19.03.15, Kubernetes 1.20.4-vmware.1, Antrea 0.11.3-vmware.2"
     mem: 2048
     name: ubuntu-20.04_tkgm-1.20_antrea-0.11
     revision: 1
@@ -13,8 +13,8 @@ templates:
     os: "ubuntu-20.04"
     docker_version: "19.03.15"
     kubernetes: "TKGm"
-    kubernetes_version: "1.20.4"
+    kubernetes_version: "1.20.4-vmware.1"
     cni: "antrea"
-    cni_version: "0.11.3"
+    cni_version: "0.11.3-vmware.2"
     upgrade_from:
       - ""


### PR DESCRIPTION
I tested using a bad registry, and the kubeadm init failed. This means that the kubeadm init is using local images.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ltimothy7/container-service-extension-templates/4)
<!-- Reviewable:end -->
